### PR TITLE
회원 비밀번호 encoding 기능 추가

### DIFF
--- a/src/main/java/com/alfa/alfadairy/account/AccountService.java
+++ b/src/main/java/com/alfa/alfadairy/account/AccountService.java
@@ -3,6 +3,7 @@ package com.alfa.alfadairy.account;
 import lombok.RequiredArgsConstructor;
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 import javax.transaction.Transactional;
@@ -14,6 +15,7 @@ public class AccountService {
 
     private final AccountRepository accountRepository;
     private final JavaMailSender javaMailSender;
+    private final PasswordEncoder passwordEncoder;
 
 
     public void processNewAccount(SignUpForm signUpForm) {
@@ -26,7 +28,7 @@ public class AccountService {
         Account account = Account.builder()
                 .userId(signUpForm.getUserId())
                 .email(signUpForm.getEmail())
-                .password(signUpForm.getPassword())
+                .password(passwordEncoder.encode(signUpForm.getPassword()))
                 .build();
 
         Account newAccount = accountRepository.save(account);

--- a/src/main/java/com/alfa/alfadairy/config/SecurityConfig.java
+++ b/src/main/java/com/alfa/alfadairy/config/SecurityConfig.java
@@ -4,6 +4,8 @@ import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
@@ -18,5 +20,10 @@ public class SecurityConfig {
                         "/sign-up"
                 ).permitAll()
                 .anyRequest().authenticated()).build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder(){
+        return PasswordEncoderFactories.createDelegatingPasswordEncoder();
     }
 }

--- a/src/test/java/com/alfa/alfadairy/account/AccountControllerTest.java
+++ b/src/test/java/com/alfa/alfadairy/account/AccountControllerTest.java
@@ -66,6 +66,7 @@ class AccountControllerTest {
         Account account = accountRepository.findByEmail("test@test.com");
         assertNotNull(account);
         assertNotNull(account.getEmailCheckToken());
+        assertNotEquals(account.getPassword(), "123456789");
         then(javaMailSender).should().send(any(SimpleMailMessage.class));
     }
 }


### PR DESCRIPTION
회원 가입 시, raw 비밀번호가 그대로 노출되기 때문에 PasswordEncoder를 Bean으로 등록해 비밀번호를 Encoding 해준다.

* Spring Security가 제공하는 createDelegatingPasswordEncoder()를 사용하게 되면
여러 Encoder 메소드가 존재하지만, Spring Security가 권장하는 BCrypt 알고리즘을 사용했다.

* BCrypt 알고리즘은 salt라는 random한 값과 함께 raw 비밀번호를 해싱한다.

* DB에 저장된 해싱값 + 로그인시 입력하는 raw 비밀번호를 함께 해싱하게 되면, DB에 저장된 해싱값이 나오게 된다.
(이러한 과정으로 비밀번호를 Encoding 하고, 로그인 할 수 있음)

This closes #8 