### PR TITLE
회원 가입 인증 메일 링크 구현

### DIFF
--- a/src/main/java/com/alfa/alfadairy/account/Account.java
+++ b/src/main/java/com/alfa/alfadairy/account/Account.java
@@ -50,4 +50,9 @@ public class Account {
     public void generateEmailCheckToken() {
         this.emailCheckToken = UUID.randomUUID().toString();
     }
+
+    public void completeSignUp() {
+        this.emailVerified = true;
+        this.joinedAt = LocalDateTime.now();
+    }
 }

--- a/src/main/java/com/alfa/alfadairy/account/Account.java
+++ b/src/main/java/com/alfa/alfadairy/account/Account.java
@@ -49,6 +49,7 @@ public class Account {
 
     public void generateEmailCheckToken() {
         this.emailCheckToken = UUID.randomUUID().toString();
+        this.emailCheckTokenGeneratedAt = LocalDateTime.now();
     }
 
     public void completeSignUp() {

--- a/src/main/java/com/alfa/alfadairy/account/AccountController.java
+++ b/src/main/java/com/alfa/alfadairy/account/AccountController.java
@@ -19,6 +19,8 @@ public class AccountController {
 
     private final SignUpFormValidator signUpFormValidator;
     private final AccountService accountService;
+    private final AccountRepository accountRepository;
+
 
     @InitBinder("signUpForm")
     public void initBinder(WebDataBinder webDataBinder){
@@ -39,5 +41,26 @@ public class AccountController {
 
         accountService.processNewAccount(signUpForm);
         return "redirect:/";
+    }
+
+    @GetMapping("/check-email-token")
+    public String checkEmailToken(String token, String email, Model model){
+        Account account = accountRepository.findByEmail(email);
+
+        /** account가 비어있을 때 */
+        if (account == null){
+            model.addAttribute("error", "wrong.email");
+            return "account/checked-email";
+        }
+
+        /** token 값이 올바르지 않을 때 */
+        if (!account.getEmailCheckToken().equals(token)){
+            model.addAttribute("error", "wrong.token");
+            return "account/checked-email";
+        }
+
+        accountService.completeSignUp(account);
+        model.addAttribute("userId", account.getUserId());
+        return "account/checked-email";
     }
 }

--- a/src/main/java/com/alfa/alfadairy/account/AccountService.java
+++ b/src/main/java/com/alfa/alfadairy/account/AccountService.java
@@ -43,4 +43,8 @@ public class AccountService {
 
         javaMailSender.send(mailMessage);
     }
+
+    public void completeSignUp(Account account) {
+        account.completeSignUp();
+    }
 }

--- a/src/main/java/com/alfa/alfadairy/config/SecurityConfig.java
+++ b/src/main/java/com/alfa/alfadairy/config/SecurityConfig.java
@@ -17,7 +17,8 @@ public class SecurityConfig {
                 PathRequest.toStaticResources().atCommonLocations()).permitAll()
                 .mvcMatchers(
                         "/",
-                        "/sign-up"
+                        "/sign-up",
+                        "/check-email-token"
                 ).permitAll()
                 .anyRequest().authenticated()).build();
     }

--- a/src/main/resources/templates/account/checked-email.html
+++ b/src/main/resources/templates/account/checked-email.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Title</title>
+</head>
+<body>
+    <div class="py-5 text-center" th:if="${error}">
+        <p class="lead">스터디올래 이메일 확인</p>
+        <div class="alert alert-danger" role="alert">
+            <svg class="bi flex-shrink-0 me-2" width="24" height="24" role="img" aria-label="Danger:"><use xlink:href="#exclamation-triangle-fill"/></svg>
+            이메일 확인 링크가 정확하지 않습니다
+        </div>
+    </div>
+
+    <div class="py-5 text-center" th:if="${error == null}">
+        <p class="lead">스터디올래 이메일 확인</p>
+        <h2>
+            이메일을 확인했습니다.
+            <span th:text="${userId}">닉네임</span>님 가입을 축하합니다.
+        </h2>
+        <small class="text-info">이제부터 가입할 때 사용한 이메일 또는 닉네임과 패스트워드로 로그인 할 수 있습니다.</small>
+    </div>
+
+</body>
+</html>

--- a/src/test/java/com/alfa/alfadairy/account/AccountControllerTest.java
+++ b/src/test/java/com/alfa/alfadairy/account/AccountControllerTest.java
@@ -30,6 +30,40 @@ class AccountControllerTest {
 
     @MockBean JavaMailSender javaMailSender;
 
+    @DisplayName("이메일 전송 - 입력값 오류")
+    @Test
+    public void checkEmailToken_wrong_input() throws Exception {
+        mvc.perform(get("/check-email-token")
+                        .param("token", "adfdfasdfas")
+                        .param("email", "test@dddd.com")
+                )
+                .andExpect(status().isOk())
+                .andExpect(model().attributeExists("error"))
+                .andExpect(view().name("account/checked-email"));
+    }
+
+    @DisplayName("이메일 전송 - 입력값 정상")
+    @Test
+    public void checkEmailToken() throws Exception {
+        Account account = Account.builder()
+                .userId("test")
+                .email("test@test.com")
+                .password("123456789")
+                .build();
+        Account newAccount = accountRepository.save(account);
+        newAccount.generateEmailCheckToken();
+
+
+        mvc.perform(get("/check-email-token")
+                        .param("token", newAccount.getEmailCheckToken())
+                        .param("email", newAccount.getEmail())
+                )
+                .andExpect(status().isOk())
+                .andExpect(model().attributeDoesNotExist("error"))
+                .andExpect(model().attributeExists("userId"))
+                .andExpect(view().name("account/checked-email"));
+    }
+
     @DisplayName("회원 가입 화면이 보이는지 확인")
     @Test
     public void signUpView() throws Exception {


### PR DESCRIPTION
회원 가입이 완료된 후, 이메일로 전송될 링크 구현

이메일에 담긴 링크를 눌렀을 때 토큰 값과 이메일을 확인해서 확인이 된다면,
이메일 인증이 완료되고 가입처리가 최종적으로 마무리 될 수 있도록 구현했다.

This closes #10 