### PR TITLE
인증된 유저 정보 확인 & 이메일 인증 경고

### DIFF
--- a/src/main/java/com/alfa/alfadairy/account/AccountService.java
+++ b/src/main/java/com/alfa/alfadairy/account/AccountService.java
@@ -55,9 +55,9 @@ public class AccountService {
         login(account);
     }
 
-    public void login(Account account) {
+    public void login(Account account){
         UsernamePasswordAuthenticationToken token = new UsernamePasswordAuthenticationToken(
-                account.getUserId(),
+                new UserAccount(account),
                 account.getPassword(),
                 List.of(new SimpleGrantedAuthority("ROLE_USER")));
 

--- a/src/main/java/com/alfa/alfadairy/account/CurrentAccount.java
+++ b/src/main/java/com/alfa/alfadairy/account/CurrentAccount.java
@@ -1,0 +1,14 @@
+package com.alfa.alfadairy.account;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.PARAMETER)
+@AuthenticationPrincipal(expression = "#this == 'anonymousUser' ? null : account")
+public @interface CurrentAccount {
+}

--- a/src/main/java/com/alfa/alfadairy/account/UserAccount.java
+++ b/src/main/java/com/alfa/alfadairy/account/UserAccount.java
@@ -1,0 +1,18 @@
+package com.alfa.alfadairy.account;
+
+import lombok.Getter;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+
+import java.util.List;
+
+@Getter
+public class UserAccount extends User {
+
+    private Account account;
+
+    public UserAccount(Account account){
+        super(account.getUserId(), account.getPassword(), List.of(new SimpleGrantedAuthority("ROLE_USER")));
+        this.account = account;
+    }
+}

--- a/src/main/java/com/alfa/alfadairy/main/MainController.java
+++ b/src/main/java/com/alfa/alfadairy/main/MainController.java
@@ -1,11 +1,20 @@
 package com.alfa.alfadairy.main;
 
+import com.alfa.alfadairy.account.Account;
+import com.alfa.alfadairy.account.CurrentAccount;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 
+@Controller
 public class MainController {
 
     @GetMapping("/")
-    public String home(){
+    public String home(@CurrentAccount Account account, Model model){
+        if (account != null){
+            model.addAttribute(account);
+        }
+
         return "index";
     }
 }

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -7,6 +7,10 @@
 
 <body>
 
+    <div class="alert alert-warning" role="alert" th:if="${account != null && !account.emailVerified}">
+        알파축산 가입을 완료하려면 <a href="#" th:href="@{/check-email}" class="alert-link">계정 인증 이메일을 확인</a>하세요.
+    </div>
+
     <!-- Modal start -->
     <div th:replace="modal.html :: #onloadModal"></div>
     <!-- Modal end -->


### PR DESCRIPTION
principal에 UserAccount를 추가해주고, UserAccount 속 account 정보를 사용할 수 있도록 구현해 줬다.
그리고 index 화면에서 회원 가입이 완료 됐지만, 이메일 인증이 완료되지 않은 유저는 경고를 볼 수 있도록 해주었다.

This closes #20 